### PR TITLE
Allow Optional Registry Credentials

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -14,11 +14,15 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        environment: {{ .Values.environment }}  
+        environment: {{ .Values.environment }}
       annotations:
         redeployOnChange: "{{ .Values.container.redeployOnChange }}"
     spec:
       restartPolicy: {{ .Values.container.restartPolicy }}
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecret }}
+      {{- end }}
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,6 +7,7 @@ postgresExternalName: host.docker.internal
 postgresPort: 5432
 name: mine-support-claim-service
 image: mine-support-claim-service
+imagePullSecret:
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-440

To deploy from a private registry into a Kubernetes cluster registry
credentials must be supplied. this PR adds configuration to the
deployment chart to allow authentication.