### PR TITLE
Add healthcheck probes for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,21 @@ The external network is declared in a secondary Docker Compose configuration (re
 
 The service has been developed with the intention of running on Kubernetes in production.  A helm chart is included in the `.\helm` folder. For development, it is simpler to develop using Docker Compose than to set up a local Kubernetes environment. See above for instructions.
 
-Running via Helm requires a local Postgres database to be installed and setup with the username and password defined in the [values.yaml](./helm/values.yaml).
+Running via Helm requires a local AMQP message broker and Postgres database to be installed and setup with the credentials defined in the [values.yaml](./helm/values.yaml).
 
-To test Helm deployments locally, a [deploy](./deploy) script is provided.
+Convenience scripts are provided which deploy all dependencies and the service into the current Helm/Kubernetes context. These should be used to test local changes to Helm charts:
 
 ```
 # Build service containers
 scripts/build
 
-# Deploy to the current Helm context
-scripts/deploy
+# Deploy to current Kubernetes context
+scripts/helm/install
+
+# Remove from current Kubernetes context
+scripts/helm/delete
 ```
+
 ### Accessing the pod
 
 The mine-support-claim-service is not exposed via an endpoint within Kubernetes.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ curl  -i --header "Content-Type: application/json" \
   http://localhost:3003/submit
 ```
 
+### Probes
+
+The service has both an Http readiness probe and an Http liveness probe configured to receive at the below end points.
+
+Readiness: `/healthy`
+Liveness: `/healthz`
+
 # Build Pipeline
 
 The [azure-pipelines.yaml](azure-pipelines.yaml) performs the following tasks:
@@ -133,4 +140,3 @@ The [azure-pipelines.yaml](azure-pipelines.yaml) performs the following tasks:
 Builds will be deployed into a namespace with the format `mine-support-claim-service-{identifier}` where `{identifier}` is either the release version, the PR number, or the branch name.
 
 A detailed description on the build pipeline and PR work flow is available in the [Defra Confluence page](https://eaflood.atlassian.net/wiki/spaces/FFCPD/pages/1281359920/Build+Pipeline+and+PR+Workflow)
-

--- a/helm/artemis-values.yaml
+++ b/helm/artemis-values.yaml
@@ -1,0 +1,5 @@
+artemisUser: artemis
+artemisPassword: artemis
+replicas: 1
+persistence:
+  enabled: false

--- a/helm/development-values.yaml
+++ b/helm/development-values.yaml
@@ -1,0 +1,6 @@
+container:
+  command: ["/bin/sh","-c"]
+  args: ["scripts/wait-for/wait-for $(POSTGRES_HOST):5432 -- npm --no-update-notifier run migrate && node index"]
+  messageQueueHost: mine-support-claim-artemis-activemq-artemis
+postgresHost: mine-support-claim-postgres-postgresql
+postgresServiceName: mine-support-claim-postgres

--- a/helm/postgres-values.yaml
+++ b/helm/postgres-values.yaml
@@ -1,0 +1,7 @@
+persistence:
+  enabled: false
+postgresqlDatabase: mine_claims
+postgresqlPassword: changeme
+postgresqlUsername: postgres@mine-support2
+service:
+  port: 5432

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -86,4 +86,18 @@ spec:
               value: {{ .Values.container.scheduleQueuePassword }}
             - name: PORT
               value: "3003"
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 status: {}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.postgresHost }}
+  name: {{ .Values.postgresServiceName }}
 spec:
   type: ExternalName
   externalName: {{ .Values.postgresExternalName }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,6 +3,7 @@ postgresUsername: postgres@mine-support2
 postgresPassword: changeme
 postgresDatabase: mine_claims
 postgresHost:  mine-support-claims-postgres
+postgresServiceName:  mine-support-claims-postgres
 postgresExternalName: host.docker.internal
 postgresPort: 5432
 name: mine-support-claim-service
@@ -24,7 +25,7 @@ container:
   allowPrivilegeEscalation: false
   restartPolicy: Always
   command: ["/bin/sh","-c"]
-  args: ["npm run migrate; node index"]
+  args: ["scripts/wait-for/wait-for $(POSTGRES_HOST):5432 -- npm --no-update-notifier run migrate && node index"]
   messageQueueHost: mine-support-artemis
   messageQueuePort: 5672
   messageQueueTransport: tcp

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,13 +40,13 @@ minReadySeconds: 10
 maxSurge: 1
 maxUnavailable: 1
 livenessProbe:
-  path: /healthy
+  path: /healthz
   port: 3003
   initialDelaySeconds: 10
   periodSeconds: 10
   failureThreshold: 3
 readinessProbe:
-  path: /healthz
+  path: /healthy
   port: 3003
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,3 +38,15 @@ replicaCount: 1
 minReadySeconds: 10
 maxSurge: 1
 maxUnavailable: 1
+livenessProbe:
+  path: /healthy
+  port: 3003
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3
+readinessProbe:
+  path: /healthz
+  port: 3003
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 3

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,7 +25,7 @@ container:
   allowPrivilegeEscalation: false
   restartPolicy: Always
   command: ["/bin/sh","-c"]
-  args: ["scripts/wait-for/wait-for $(POSTGRES_HOST):5432 -- npm --no-update-notifier run migrate && node index"]
+  args: ["npm --no-update-notifier run migrate && node index"]
   messageQueueHost: mine-support-artemis
   messageQueuePort: 5672
   messageQueueTransport: tcp

--- a/scripts/helm/delete
+++ b/scripts/helm/delete
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/../.." || return; pwd)"
+
+(
+  cd "${projectRoot}"
+
+  helm delete --purge \
+    mine-support-claim-artemis \
+    mine-support-claim-postgres \
+    mine-support-claim-service
+)

--- a/scripts/helm/install
+++ b/scripts/helm/install
@@ -38,9 +38,7 @@ projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/../.." || return
     --atomic \
     --install \
     --namespace mine-support-claim-service \
-    --set postgresHost=mine-support-claim-postgres-postgresql \
-    --set container.messageQueueHost=mine-support-claim-artemis-activemq-artemis \
-    --set postgresServiceName=mine-support-claim-postgres \
+    --values helm/development-values.yaml \
     --wait \
     mine-support-claim-service \
     ./helm

--- a/scripts/helm/install
+++ b/scripts/helm/install
@@ -12,10 +12,7 @@ projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/../.." || return
     --atomic \
     --install \
     --namespace mine-support-claim-service \
-    --set artemisUser=artemis \
-    --set artemisPassword=artemis \
-    --set replicas=1 \
-    --set persistence.enabled=false \
+    --values helm/artemis-values.yaml \
     mine-support-claim-artemis \
     activemq-artemis/activemq-artemis
 
@@ -24,11 +21,7 @@ projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/../.." || return
     --atomic \
     --install \
     --namespace mine-support-claim-service \
-    --set persistence.enabled=false \
-    --set postgresqlDatabase=mine_claims \
-    --set postgresqlPassword=changeme \
-    --set postgresqlUsername=postgres@mine-support2 \
-    --set service.port=5432 \
+    --values helm/postgres-values.yaml \
     --wait \
     mine-support-claim-postgres \
     stable/postgresql

--- a/scripts/helm/install
+++ b/scripts/helm/install
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -e
+projectRoot="$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/../.." || return; pwd)"
+
+(
+  cd "${projectRoot}"
+
+  echo "Deploying claim message queue"
+  helm repo add activemq-artemis https://mailrucloudsolutions.github.io/activemq-artemis-helm/
+  helm upgrade \
+    --atomic \
+    --install \
+    --namespace mine-support-claim-service \
+    --set artemisUser=artemis \
+    --set artemisPassword=artemis \
+    --set replicas=1 \
+    --set persistence.enabled=false \
+    mine-support-claim-artemis \
+    activemq-artemis/activemq-artemis
+
+  echo "Deploying claim PostgreSQL"
+  helm upgrade \
+    --atomic \
+    --install \
+    --namespace mine-support-claim-service \
+    --set persistence.enabled=false \
+    --set postgresqlDatabase=mine_claims \
+    --set postgresqlPassword=changeme \
+    --set postgresqlUsername=postgres@mine-support2 \
+    --set service.port=5432 \
+    --wait \
+    mine-support-claim-postgres \
+    stable/postgresql
+
+  echo "Deploying claim service"
+  helm upgrade \
+    --atomic \
+    --install \
+    --namespace mine-support-claim-service \
+    --set postgresHost=mine-support-claim-postgres-postgresql \
+    --set container.messageQueueHost=mine-support-claim-artemis-activemq-artemis \
+    --set postgresServiceName=mine-support-claim-postgres \
+    --wait \
+    mine-support-claim-service \
+    ./helm
+)

--- a/server/plugins/router.js
+++ b/server/plugins/router.js
@@ -1,6 +1,8 @@
 const routes = [].concat(
-  require('../routes/submit'),
-  require('../routes/error')
+  require('../routes/error'),
+  require('../routes/healthy'),
+  require('../routes/healthz'),
+  require('../routes/submit')
 )
 
 module.exports = {

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -6,24 +6,30 @@ module.exports = {
   path: '/healthy',
   options: {
     handler: async (request, h) => {
-      let message = 'ok'
-      let statusCode = 200
+      const calculationSender = messageService.getCalculationSender()
+      const scheduleSender = messageService.getScheduleSender()
+
       const unavailableServices = []
 
       if (!await databaseService.isConnected()) {
         unavailableServices.push('database')
       }
 
-      if (!messageService.isConnected()) {
-        unavailableServices.push('message queue')
+      if (!calculationSender.isConnected()) {
+        unavailableServices.push('calculation queue')
       }
+
+      if (!scheduleSender.isConnected()) {
+        unavailableServices.push('schedule queue')
+      }
+
+      let message = 'ok'
+      let statusCode = 200
 
       if (unavailableServices.length > 0) {
         message = 'Downstream services unavailable: ' + unavailableServices.join(', ')
         statusCode = 500
       }
-
-      console.debug(message)
 
       return h.response(message).code(statusCode)
     }

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -1,0 +1,9 @@
+module.exports = {
+  method: 'GET',
+  path: '/healthy',
+  options: {
+    handler: async (request, h) => {
+      return h.response('ok').code(200)
+    }
+  }
+}

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -1,9 +1,31 @@
+const databaseService = require('../services/database-service')
+const messageService = require('../services/message-service')
+
 module.exports = {
   method: 'GET',
   path: '/healthy',
   options: {
     handler: async (request, h) => {
-      return h.response('ok').code(200)
+      let message = 'ok'
+      let statusCode = 200
+      const unavailableServices = []
+
+      if (!await databaseService.isConnected()) {
+        unavailableServices.push('database')
+      }
+
+      if (!messageService.isConnected()) {
+        unavailableServices.push('message queue')
+      }
+
+      if (unavailableServices.length > 0) {
+        message = 'Downstream services unavailable: ' + unavailableServices.join(', ')
+        statusCode = 500
+      }
+
+      console.debug(message)
+
+      return h.response(message).code(statusCode)
     }
   }
 }

--- a/server/routes/healthy.js
+++ b/server/routes/healthy.js
@@ -15,13 +15,13 @@ module.exports = {
         scheduleQueue: scheduleSender.isConnected()
       }
 
-      const disconnected = Object.keys(connections)
+      const brokenConnections = Object.keys(connections)
         .filter(service => !connections[service])
         .join(', ')
 
-      const allConnected = disconnected.length === 0
+      const allConnected = brokenConnections.length === 0
 
-      const message = allConnected ? 'ok' : `Dependencies unavailable: ${disconnected}`
+      const message = allConnected ? 'ok' : `Dependencies unavailable: ${brokenConnections}`
       const statusCode = allConnected ? 200 : 500
 
       return h.response(message).code(statusCode)

--- a/server/routes/healthz.js
+++ b/server/routes/healthz.js
@@ -1,0 +1,9 @@
+module.exports = {
+  method: 'GET',
+  path: '/healthz',
+  options: {
+    handler: async (request, h) => {
+      return h.response('ok').code(200)
+    }
+  }
+}

--- a/server/services/database-service.js
+++ b/server/services/database-service.js
@@ -1,0 +1,13 @@
+const db = require('../models')
+
+module.exports = {
+  isConnected: async function () {
+    try {
+      await db.sequelize.authenticate()
+      return true
+    } catch (err) {
+      console.log(err)
+      return false
+    }
+  }
+}

--- a/server/services/message-service.js
+++ b/server/services/message-service.js
@@ -31,14 +31,19 @@ async function publishClaim (claim) {
   }
 }
 
-function isConnected () {
-  return calculationSender.isOpen() && scheduleSender.isOpen()
+function getCalculationSender () {
+  return calculationSender
+}
+
+function getScheduleSender () {
+  return scheduleSender
 }
 
 module.exports = {
-  registerQueues,
-  publishClaim,
-  openConnections,
   closeConnections,
-  isConnected
+  getCalculationSender,
+  getScheduleSender,
+  openConnections,
+  publishClaim,
+  registerQueues
 }

--- a/server/services/message-service.js
+++ b/server/services/message-service.js
@@ -1,5 +1,4 @@
 const MessageSender = require('./messaging/message-sender')
-console.debug('getting config')
 const config = require('../config')
 
 const calculationSender = new MessageSender('claim-service-calculation-sender', config.messageQueues.calculationQueue)
@@ -31,9 +30,15 @@ async function publishClaim (claim) {
     throw err
   }
 }
+
+function isConnected () {
+  return calculationSender.isOpen() && scheduleSender.isOpen()
+}
+
 module.exports = {
   registerQueues,
   publishClaim,
   openConnections,
-  closeConnections
+  closeConnections,
+  isConnected
 }

--- a/server/services/messaging/message-base.js
+++ b/server/services/messaging/message-base.js
@@ -20,6 +20,10 @@ class MessageBase {
     await this.connection.close()
     console.log(`${this.name} connection closed`)
   }
+
+  isOpen () {
+    return this.connection.isOpen()
+  }
 }
 
 module.exports = MessageBase

--- a/server/services/messaging/message-base.js
+++ b/server/services/messaging/message-base.js
@@ -21,7 +21,7 @@ class MessageBase {
     console.log(`${this.name} connection closed`)
   }
 
-  isOpen () {
+  isConnected () {
     return this.connection.isOpen()
   }
 }

--- a/test/routes/healthy.test.js
+++ b/test/routes/healthy.test.js
@@ -1,0 +1,27 @@
+describe('Healthy test', () => {
+  let createServer
+  let server
+
+  beforeAll(async () => {
+    createServer = require('../../server')
+  })
+
+  beforeEach(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  test('GET /healthy returns 200', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthy'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).toBe(200)
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+})

--- a/test/routes/healthy.test.js
+++ b/test/routes/healthy.test.js
@@ -55,7 +55,7 @@ describe('Healthy test', () => {
     const response = await server.inject(options)
 
     expect(response.statusCode).toBe(500)
-    expect(response.payload).toBe('Downstream services unavailable: database')
+    expect(response.payload).toBe('Dependencies unavailable: database')
   })
 
   test('GET /healthy returns 500 if calculation queue not connected', async () => {
@@ -71,7 +71,7 @@ describe('Healthy test', () => {
     const response = await server.inject(options)
 
     expect(response.statusCode).toBe(500)
-    expect(response.payload).toBe('Downstream services unavailable: calculation queue')
+    expect(response.payload).toBe('Dependencies unavailable: calculationQueue')
   })
 
   test('GET /healthy returns 500 if schedule queue not connected', async () => {
@@ -87,7 +87,7 @@ describe('Healthy test', () => {
     const response = await server.inject(options)
 
     expect(response.statusCode).toBe(500)
-    expect(response.payload).toBe('Downstream services unavailable: schedule queue')
+    expect(response.payload).toBe('Dependencies unavailable: scheduleQueue')
   })
 
   test('GET /healthy returns 500 with appropriate message if all downstream services are disconnected', async () => {
@@ -103,7 +103,7 @@ describe('Healthy test', () => {
     const response = await server.inject(options)
 
     expect(response.statusCode).toBe(500)
-    expect(response.payload).toBe('Downstream services unavailable: database, calculation queue, schedule queue')
+    expect(response.payload).toBe('Dependencies unavailable: calculationQueue, database, scheduleQueue')
   })
 
   afterEach(async () => {

--- a/test/routes/healthy.test.js
+++ b/test/routes/healthy.test.js
@@ -1,14 +1,24 @@
 describe('Healthy test', () => {
+  let calculationSender = {}
   let createServer
   let databaseService
   let messageService
+  let scheduleSender = {}
   let server
 
   beforeAll(async () => {
     jest.mock('../../server/services/database-service')
     jest.mock('../../server/services/message-service')
+
     databaseService = require('../../server/services/database-service')
     messageService = require('../../server/services/message-service')
+
+    messageService.getCalculationSender = jest.fn().mockReturnValue(calculationSender)
+    messageService.getScheduleSender = jest.fn().mockReturnValue(scheduleSender)
+
+    calculationSender.isConnected = jest.fn().mockReturnValue(false)
+    scheduleSender.isConnected = jest.fn().mockReturnValue(false)
+
     createServer = require('../../server')
   })
 
@@ -24,7 +34,8 @@ describe('Healthy test', () => {
     }
 
     databaseService.isConnected = jest.fn().mockReturnValue(true)
-    messageService.isConnected = jest.fn().mockReturnValue(true)
+    calculationSender.isConnected = jest.fn().mockReturnValue(true)
+    scheduleSender.isConnected = jest.fn().mockReturnValue(true)
 
     const response = await server.inject(options)
 
@@ -38,7 +49,8 @@ describe('Healthy test', () => {
     }
 
     databaseService.isConnected = jest.fn().mockReturnValue(false)
-    messageService.isConnected = jest.fn().mockReturnValue(true)
+    calculationSender.isConnected = jest.fn().mockReturnValue(true)
+    scheduleSender.isConnected = jest.fn().mockReturnValue(true)
 
     const response = await server.inject(options)
 
@@ -46,34 +58,52 @@ describe('Healthy test', () => {
     expect(response.payload).toBe('Downstream services unavailable: database')
   })
 
-  test('GET /healthy returns 500 if message queue not connected', async () => {
+  test('GET /healthy returns 500 if calculation queue not connected', async () => {
     const options = {
       method: 'GET',
       url: '/healthy'
     }
 
     databaseService.isConnected = jest.fn().mockReturnValue(true)
-    messageService.isConnected = jest.fn().mockReturnValue(false)
+    calculationSender.isConnected = jest.fn().mockReturnValue(false)
+    scheduleSender.isConnected = jest.fn().mockReturnValue(true)
 
     const response = await server.inject(options)
 
     expect(response.statusCode).toBe(500)
-    expect(response.payload).toBe('Downstream services unavailable: message queue')
+    expect(response.payload).toBe('Downstream services unavailable: calculation queue')
   })
 
-  test('GET /healthy returns appropriate error message if all downstream services not connected', async () => {
+  test('GET /healthy returns 500 if schedule queue not connected', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthy'
+    }
+
+    databaseService.isConnected = jest.fn().mockReturnValue(true)
+    calculationSender.isConnected = jest.fn().mockReturnValue(true)
+    scheduleSender.isConnected = jest.fn().mockReturnValue(false)
+
+    const response = await server.inject(options)
+
+    expect(response.statusCode).toBe(500)
+    expect(response.payload).toBe('Downstream services unavailable: schedule queue')
+  })
+
+  test('GET /healthy returns 500 with appropriate message if all downstream services are disconnected', async () => {
     const options = {
       method: 'GET',
       url: '/healthy'
     }
 
     databaseService.isConnected = jest.fn().mockReturnValue(false)
-    messageService.isConnected = jest.fn().mockReturnValue(false)
+    calculationSender.isConnected = jest.fn().mockReturnValue(false)
+    scheduleSender.isConnected = jest.fn().mockReturnValue(false)
 
     const response = await server.inject(options)
 
     expect(response.statusCode).toBe(500)
-    expect(response.payload).toBe('Downstream services unavailable: database, message queue')
+    expect(response.payload).toBe('Downstream services unavailable: database, calculation queue, schedule queue')
   })
 
   afterEach(async () => {

--- a/test/routes/healthy.test.js
+++ b/test/routes/healthy.test.js
@@ -1,8 +1,14 @@
 describe('Healthy test', () => {
   let createServer
+  let databaseService
+  let messageService
   let server
 
   beforeAll(async () => {
+    jest.mock('../../server/services/database-service')
+    jest.mock('../../server/services/message-service')
+    databaseService = require('../../server/services/database-service')
+    messageService = require('../../server/services/message-service')
     createServer = require('../../server')
   })
 
@@ -17,8 +23,57 @@ describe('Healthy test', () => {
       url: '/healthy'
     }
 
+    databaseService.isConnected = jest.fn().mockReturnValue(true)
+    messageService.isConnected = jest.fn().mockReturnValue(true)
+
     const response = await server.inject(options)
+
     expect(response.statusCode).toBe(200)
+  })
+
+  test('GET /healthy returns 500 if database not connected', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthy'
+    }
+
+    databaseService.isConnected = jest.fn().mockReturnValue(false)
+    messageService.isConnected = jest.fn().mockReturnValue(true)
+
+    const response = await server.inject(options)
+
+    expect(response.statusCode).toBe(500)
+    expect(response.payload).toBe('Downstream services unavailable: database')
+  })
+
+  test('GET /healthy returns 500 if message queue not connected', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthy'
+    }
+
+    databaseService.isConnected = jest.fn().mockReturnValue(true)
+    messageService.isConnected = jest.fn().mockReturnValue(false)
+
+    const response = await server.inject(options)
+
+    expect(response.statusCode).toBe(500)
+    expect(response.payload).toBe('Downstream services unavailable: message queue')
+  })
+
+  test('GET /healthy returns appropriate error message if all downstream services not connected', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthy'
+    }
+
+    databaseService.isConnected = jest.fn().mockReturnValue(false)
+    messageService.isConnected = jest.fn().mockReturnValue(false)
+
+    const response = await server.inject(options)
+
+    expect(response.statusCode).toBe(500)
+    expect(response.payload).toBe('Downstream services unavailable: database, message queue')
   })
 
   afterEach(async () => {

--- a/test/routes/healthz.test.js
+++ b/test/routes/healthz.test.js
@@ -1,0 +1,27 @@
+describe('Healthz test', () => {
+  let createServer
+  let server
+
+  beforeAll(async () => {
+    createServer = require('../../server')
+  })
+
+  beforeEach(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  test('GET /healthz returns 200', async () => {
+    const options = {
+      method: 'GET',
+      url: '/healthz'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).toBe(200)
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-471

Liveness probe simply confirms the service is running.
Readiness probe tests database and message queue connections. If the readiness probe fails, it responds with a list of disconnected services to assist in diagnosing problems.